### PR TITLE
Use authuser query param for Gmail desktop link

### DIFF
--- a/app/v1/render/providers.ts
+++ b/app/v1/render/providers.ts
@@ -49,8 +49,13 @@ export const PROVIDERS: ReadonlyArray<Provider> = [
     name: "gmail",
     prettyName: "Gmail",
     domains: ["gmail.com", "googlemail.com", "google.com"],
+    // Gmail's `/u/<X>/` segment expects a numeric account index, not an email.
+    // Passing an email works only when that account happens to be signed in at
+    // that index; for Workspace/custom-domain accounts or not-signed-in users it
+    // throws an error before the `#search` fragment ever runs. `authuser` is the
+    // resolver Gmail itself uses to hand off to the right account (or to sign-in).
     getDesktopLink: ({ recipient, sender }) =>
-      `https://mail.google.com/mail/u/${encodeURIComponent(recipient)}/#search/from%3A(${encodeURIComponent(sender)})+in%3Aanywhere+newer_than%3A1h`,
+      `https://mail.google.com/mail/u/0/?authuser=${encodeURIComponent(recipient)}#search/from%3A(${encodeURIComponent(sender)})+in%3Aanywhere+newer_than%3A1h`,
     getIosLink: () => "googlegmail://",
     getAndroidLink: () =>
       getAndroidIntentUrl("com.google.android.gm", "https://mail.google.com/"),

--- a/app/v1/render/route.test.ts
+++ b/app/v1/render/route.test.ts
@@ -207,8 +207,8 @@ describe("provider desktop links", () => {
 
   it("gmail: searches by sender in recipient's mailbox", () => {
     const url = find("gmail").getDesktopLink(opts);
-    expect(url).toContain("mail.google.com/mail/u/");
-    expect(url).toContain(encodeURIComponent(opts.recipient));
+    expect(url).toContain("mail.google.com/mail/u/0/");
+    expect(url).toContain(`authuser=${encodeURIComponent(opts.recipient)}`);
     expect(url).toContain(encodeURIComponent(opts.sender));
     expect(url).toContain("newer_than%3A1h");
   });


### PR DESCRIPTION
## Summary

- Gmail's `/mail/u/<X>/` path expects a numeric account index. Passing a raw email only resolves if that account happens to be signed in at that slot; Workspace/custom-domain accounts and not-signed-in users land on an error page before the `#search` fragment ever runs.
- Switch to `/mail/u/0/?authuser=<email>` — Gmail's own account resolver, which falls through to sign-in rather than erroring.

Before:
```
https://mail.google.com/mail/u/anita%40buttondown.email/#search/from%3A(info%40newsletter.queertransproject.org)+in%3Aanywhere+newer_than%3A1h
```

After:
```
https://mail.google.com/mail/u/0/?authuser=anita%40buttondown.email#search/from%3A(info%40newsletter.queertransproject.org)+in%3Aanywhere+newer_than%3A1h
```

## Test plan

- [x] `bun x vitest run` — all 54 tests pass; Gmail test updated to assert the new URL shape
- [ ] Manual: open the generated URL while signed out of the target Workspace account; should land on Gmail sign-in (previously errored)
- [ ] Manual: open while signed into multiple accounts; should route to the correct one and run the search

🤖 Generated with [Claude Code](https://claude.com/claude-code)